### PR TITLE
add a provider id; do not complete when provider.

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -1,4 +1,4 @@
-<form class="form-horizontal">
+<form class="form-horizontal" {{#if provId}}data-provider-id = "{{provId}}" {{/if}}>
 
   {{#if options.label}}
     <div class="form-group clearfix">

--- a/js/interface.js
+++ b/js/interface.js
@@ -59,9 +59,17 @@ $('form').submit(function (event) {
   fields.forEach(function (fieldId) {
     data[fieldId] = $('#' + fieldId).val();
   });
+  // if the link is a provider link set the provider ID.
+  // this will be used for us to be able to differentiate multiple link
+  // providers per parent widget.
+  if(Fliplet.Env.get('provider')) {
+    data.provId = $('[data-provider-id]').length ? $('[data-provider-id]')[0].dataset.providerId : null;
+  }
 
   Fliplet.Widget.save(data).then(function () {
-    Fliplet.Widget.complete();
+    if(!Fliplet.Env.get('provider')) {
+      Fliplet.Widget.complete();
+    }
   });
 });
 


### PR DESCRIPTION
Added a provider id to the link plugin, for us to be able to from a master plugin to know to which provider a saved data belongs to.
When the link is a provider the Widget.Complete is invoked inside the Widget.Save therefore you only need to save once and do not execute the Widget.Complete after the Widget.Save.

Related to the PR https://github.com/Fliplet/fliplet-api/pull/247
