### PR TITLE
better regexp on link provider

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -60,7 +60,7 @@ $('form').submit(function (event) {
     data[fieldId] = $('#' + fieldId).val();
   });
 
-  if (data.url && !data.url.match(/^https?:\/\//i)) {
+  if (data.url && !data.url.match(/^[A-z]+:/i)) {
     data.url = 'http://' + data.url;
   }
 


### PR DESCRIPTION
Allows links with protocols like `tel:` and `mailto:` to be saved.

The provider will only prefix links with `http://` when a protocol has not been found in the string.

Closes https://github.com/Fliplet/fliplet-studio/issues/308
