### PR TITLE
Hide action selector

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -11,7 +11,7 @@
     </div>
   {{/if}}
 
-  <div id="link-action">
+  <div id="link-action" {{#if options.hideAction}} style="display: none" {{/if}}>
     <div class="form-group">
       <div class="col-sm-4 control-label">
         <label for="action">Link action</label>

--- a/interface.html
+++ b/interface.html
@@ -11,7 +11,7 @@
     </div>
   {{/if}}
 
-  <div id="link-action" {{#if options.hideAction}} style="display: none" {{/if}}>
+  <div id="link-action" {{#if options.hideAction}} class="hidden" {{/if}}>
     <div class="form-group">
       <div class="col-sm-4 control-label">
         <label for="action">Link action</label>
@@ -35,7 +35,9 @@
   </div>
 
   <div id="screenSection" class="section">
+    {{#unless options.hideAction}}
     <h2><small>Display another screen</small></h2>
+    {{/unless}}
     <div class="row">
       <div class="col-xs-12">
         <p>Link to an existing screen with a chosen animation</p>

--- a/interface.html
+++ b/interface.html
@@ -101,7 +101,9 @@
   </div>
 
   <div id="urlSection" class="section">
+    {{#unless options.hideAction}}
     <h2><small>Open a web page</small></h2>
+    {{/unless}}
     <div class="row">
       <div class="col-xs-12">
         <p>The web page will be displayed within your app.</p>


### PR DESCRIPTION
Allow link provider to open with a preselected action and hide the action selector.
For this pass an options `hideAction: true`
Sample code:
```javascript
var data = Fliplet.Widget.getData() || {};
data.action.action = 'screen';
data.action.options = { hideAction: true } ;

var linkActionProvider = Fliplet.Widget.open('com.fliplet.link', {
  selector: '#action',
  data: data.action,
});
```