### PR TITLE
Corrects screen transition labels

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -34,7 +34,6 @@
               <option value="app">Link to an external application</option>
             </select>
             <span class="icon fa fa-chevron-down"></span>
-            <span class="select-value-proxy">None</span>
           </label>
         </div>
       </div>
@@ -52,7 +51,6 @@
                 <option selected value="">Select a screen</option>
               </select>
               <span class="icon fa fa-chevron-down"></span>
-              <span class="select-value-proxy">Select a screen</span>
             </label>
             <a id="add-query" href="#">Add query variables</a>
           </div>
@@ -80,10 +78,10 @@
                   <option value="slide.right">Slide Right</option>
                   <option value="slide.up">Slide Up</option>
                   <option value="slide.down">Slide Down</option>
-                  <option value="flip.left">Flip from Left / Slide Right (Windows)</option>
-                  <option value="flip.right">Flip from Right / Slide Left (Windows)</option>
-                  <option value="flip.up">Flip from Top / Slide Up (Windows)</option>
-                  <option value="flip.down">Flip from Bottom / Slide Down (Windows)</option>
+                  <option value="flip.left">Flip Left / Slide Left (Windows)</option>
+                  <option value="flip.right">Flip Right / Slide Right (Windows)</option>
+                  <option value="flip.up">Flip Up / Slide Up (Windows)</option>
+                  <option value="flip.down">Flip Down / Slide Down (Windows)</option>
                 </optgroup>
                 <optgroup label="iOS Enhanced">
                   <option value="curl.up">Curl Up (iOS) / Slide Up (Android/Windows)</option>
@@ -91,7 +89,6 @@
                 </optgroup>
               </select>
               <span class="icon fa fa-chevron-down"></span>
-              <span class="select-value-proxy">Slide Left</span>
             </label>
           </div>
         </div>
@@ -158,7 +155,6 @@
               <option value="">Select one</option>
             </select>
             <span class="icon fa fa-chevron-down"></span>
-            <span class="select-value-proxy">Select one</span>
           </label>
         </div>
       </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -150,7 +150,6 @@ $('#action').on('change', function onLinkTypeChange() {
   var selectedText = $(this).find("option:selected").text();
   $('.section.show').removeClass('show');
   $('#' + selectedValue + 'Section').addClass('show');
-  $(this).parents('.select-proxy-display').find('.select-value-proxy').html(selectedText);
 
   /*Fliplet.Widget.emit(validInputEventName, {
     isValid: selectedValue !== 'none'
@@ -162,14 +161,11 @@ $('#action').on('change', function onLinkTypeChange() {
 
 $('#page').on('change', function onScreenListChange() {
   var selectedText = $(this).find("option:selected").text();
-  $(this).parents('.select-proxy-display').find('.select-value-proxy').html(selectedText);
 });
 
 $appAction.on('change', function onAppActionChange() {
   var selectedText = $(this).find("option:selected").text();
   var value = $(this).val();
-
-  $(this).parents('.select-proxy-display').find('.select-value-proxy').html(selectedText);
 
   // Hide visible fields if any
   $('.appLinkFields').removeClass('show');
@@ -181,7 +177,6 @@ $appAction.on('change', function onAppActionChange() {
 
 $('#transition').on('change', function onTransitionListChange() {
   var selectedText = $(this).find("option:selected").text();
-  $(this).parents('.select-proxy-display').find('.select-value-proxy').html(selectedText);
 });
 
 $('#add-query').on('click', function() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -147,7 +147,6 @@ $(window).on('resize', Fliplet.Widget.autosize);
 
 $('#action').on('change', function onLinkTypeChange() {
   var selectedValue = $(this).val();
-  var selectedText = $(this).find("option:selected").text();
   $('.section.show').removeClass('show');
   $('#' + selectedValue + 'Section').addClass('show');
 
@@ -159,12 +158,7 @@ $('#action').on('change', function onLinkTypeChange() {
   Fliplet.Widget.autosize();
 });
 
-$('#page').on('change', function onScreenListChange() {
-  var selectedText = $(this).find("option:selected").text();
-});
-
 $appAction.on('change', function onAppActionChange() {
-  var selectedText = $(this).find("option:selected").text();
   var value = $(this).val();
 
   // Hide visible fields if any
@@ -173,10 +167,6 @@ $appAction.on('change', function onAppActionChange() {
   $('.' + externalAppValueMap[value]).addClass('show');
   // Tells the parent widget this provider has changed its interface height
   Fliplet.Widget.autosize();
-});
-
-$('#transition').on('change', function onTransitionListChange() {
-  var selectedText = $(this).find("option:selected").text();
 });
 
 $('#add-query').on('click', function() {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/3097

Corrects...

```html
                  <option value="flip.left">Flip from Left / Slide Right (Windows)</option>
                  <option value="flip.right">Flip from Right / Slide Left (Windows)</option>
                  <option value="flip.up">Flip from Top / Slide Up (Windows)</option>
                  <option value="flip.down">Flip from Bottom / Slide Down (Windows)</option>
```

...to

```html
                  <option value="flip.left">Flip Left / Slide Left (Windows)</option>
                  <option value="flip.right">Flip Right / Slide Right (Windows)</option>
                  <option value="flip.up">Flip Up / Slide Up (Windows)</option>
                  <option value="flip.down">Flip Down / Slide Down (Windows)</option>
```