### PR TITLE
Removed save function call from on change event

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -150,7 +150,7 @@ $('#action').on('change', function onLinkTypeChange() {
   $('.section.show').removeClass('show');
   $('#' + selectedValue + 'Section').addClass('show');
  
-  save();
+  Fliplet.Studio.emit('widget-changed');
   /*Fliplet.Widget.emit(validInputEventName, {
     isValid: selectedValue !== 'none'
   });*/
@@ -350,7 +350,6 @@ function save(notifyComplete) {
   } else {
     Fliplet.Widget.save(data).then(function() {
       Fliplet.Studio.emit('reload-widget-instance', widgetInstanceId);
-      Fliplet.Studio.emit('widget-data', data);
     });
   }
 }


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://flipletoutsourced.slack.com/archives/CLPSXU4RF/p1570621328002300

## Description
Removed save function call from on change event to prevent further more issues with LFD and other components.

## Backward compatibility

This change is fully backward compatible.