### PR TITLE
Dropdown has "Select a screen" value as default

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -49,7 +49,7 @@
           <div class="col-sm-8">
             <label for="page" class="select-proxy-display">
               <select name="link_screen" id="page" data-label="select" class="hidden-select form-control">
-                <option selected value="">Select a screen</option>
+                <option selected value="none">Select a screen</option>
               </select>
               <span class="icon fa fa-chevron-down"></span>
             </label>


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#2793

## Description
Dropdown now has a default 'Select a screen' value.

## Screenshots/screencasts
![empty-dropdown](https://user-images.githubusercontent.com/52824207/72601467-21f92680-391e-11ea-8cc3-0702979e7014.gif)

## Backward compatibility
This change is fully backward compatible.

## Notes
This is just empty dropdown fix. Main PR for this issue is https://github.com/Fliplet/fliplet-widget-app-security/pull/21.