### PR TITLE
Ensures the "Select screen" field placeholder is shown when no pages are selected

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -49,7 +49,7 @@
           <div class="col-sm-8">
             <label for="page" class="select-proxy-display">
               <select name="link_screen" id="page" data-label="select" class="hidden-select form-control">
-                <option value="defaultSelect">Select a screen</option>
+                <option value="none">Select a screen</option>
               </select>
               <span class="icon fa fa-chevron-down"></span>
             </label>

--- a/interface.html
+++ b/interface.html
@@ -49,7 +49,7 @@
           <div class="col-sm-8">
             <label for="page" class="select-proxy-display">
               <select name="link_screen" id="page" data-label="select" class="hidden-select form-control">
-                <option selected value="none">Select a screen</option>
+                <option value="defaultSelect">Select a screen</option>
               </select>
               <span class="icon fa fa-chevron-down"></span>
             </label>

--- a/js/interface.js
+++ b/js/interface.js
@@ -386,13 +386,20 @@ function initialiseData() {
       }
     }
     $('.spinner-holder').removeClass('animated');
-    selectDefaultPage && $('#page').val('defaultSelect');
+
+    if (selectDefaultPage) {
+      $('#page').val('none');
+    }
+
     return;
   }
 
   $('.spinner-holder').removeClass('animated');
-  selectDefaultPage && $('#page').val('defaultSelect');
   $('#transition').val(defaultTransitionVal).trigger('change');
+
+  if (selectDefaultPage) {
+    $('#page').val('none');
+  }
 }
 
 Fliplet.Pages.get()

--- a/js/interface.js
+++ b/js/interface.js
@@ -2,6 +2,7 @@ var widgetInstanceId = $('[data-widget-id]').data('widget-id');
 var widgetInstanceData = Fliplet.Widget.getData(widgetInstanceId) || {};
 var customAppsList = Fliplet.Navigate.Apps.list();
 var defaultTransitionVal = 'fade';
+var selectDefaultPage = true;
 
 var fields = [
   'linkLabel',
@@ -385,23 +386,32 @@ function initialiseData() {
       }
     }
     $('.spinner-holder').removeClass('animated');
+    selectDefaultPage && $('#page').val('defaultSelect');
     return;
   }
 
   $('.spinner-holder').removeClass('animated');
+  selectDefaultPage && $('#page').val('defaultSelect');
   $('#transition').val(defaultTransitionVal).trigger('change');
 }
 
 Fliplet.Pages.get()
   .then(function(pages) {
     var $select = $('#page');
+
     (pages || []).forEach(function(page) {
       var pageIsOmited = _.some(widgetInstanceData.omitPages, function(omittedPage) {
         return omittedPage === page.id;
       });
+
       if (pageIsOmited) {
         return;
       }
+
+      if (widgetInstanceData.page) {
+        selectDefaultPage = false;
+      }
+
       $select.append(
         '<option value="' + page.id + '"' +
         (widgetInstanceData.page === page.id.toString() ? ' selected' : '') +


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5749

## Description
If no page is saved, the dropdown will switch to the default value.

## Screenshots/screencasts
![link-fix](https://user-images.githubusercontent.com/52824207/77629879-df258180-6f52-11ea-8e5b-2753902ad340.gif)

## Backward compatibility
This change is fully backward compatible.