### PR TITLE
[Fix] Fire an event on file picker close to managing save button label in the menu manager

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -121,6 +121,7 @@ Object.keys(btnSelector).forEach(function(key) {
       Fliplet.Studio.emit('widget-save-label-update', {
         text: 'Save & Close'
       });
+      Fliplet.Widget.emit('file-picker-closed');
       Fliplet.Widget.info('');
       Fliplet.Widget.toggleCancelButton(true);
       Fliplet.Widget.toggleSaveButton(true);
@@ -280,6 +281,7 @@ Fliplet.Widget.onCancelRequest(function() {
     Fliplet.Studio.emit('widget-save-label-update', {
       text: 'Save & Close'
     });
+    Fliplet.Widget.emit('file-picker-closed');
     Fliplet.Widget.toggleCancelButton(true);
     Fliplet.Widget.toggleSaveButton(true);
     Fliplet.Widget.info('');


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5564

## Description
Fire an event on file picker close to managing save button label in the menu manager

## Screenshots/screencasts
https://share.getcloudapp.com/WnuG8pRE

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
This fix should work alongside with this [PR](https://github.com/Fliplet/fliplet-widget-menu-manager/pull/30)