### PR TITLE
OD-531 [FIX] Fixed error of displaying the link provider

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -294,6 +294,9 @@ Fliplet.Studio.onMessage(function(event) {
         $('#screen-list').removeClass('has-error');
 
         break;
+      case 'show-widget':
+        Fliplet.Widget.autosize();
+        break;
       default:
         break;
     }

--- a/js/interface.js
+++ b/js/interface.js
@@ -294,7 +294,7 @@ Fliplet.Studio.onMessage(function(event) {
         $('#screen-list').removeClass('has-error');
 
         break;
-      case 'show-widget':
+      case 'widget-autosize':
         Fliplet.Widget.autosize();
 
         break;

--- a/js/interface.js
+++ b/js/interface.js
@@ -296,6 +296,7 @@ Fliplet.Studio.onMessage(function(event) {
         break;
       case 'show-widget':
         Fliplet.Widget.autosize();
+
         break;
       default:
         break;


### PR DESCRIPTION
@sofiiakvasnevska

OD-531 https://weboo.atlassian.net/browse/OD-531

## Description
**Problem:** If in the component settings you switch tabs before loading the link provider, it will not be assigned a height.
**Solution:** When a tab is opened, an event is emit to a provider that triggers the Fliplet.Widget.autosize() function inside the provider

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko